### PR TITLE
add message for update handle v2 api

### DIFF
--- a/lib/services/api/messages.rb
+++ b/lib/services/api/messages.rb
@@ -61,6 +61,12 @@ module VCAP
         required :credentials
       end
 
+      class HandleUpdateRequestV2 < JsonMessage
+        required :token, String
+        required :gateway_data
+        required :credentials
+      end
+
       class ListHandlesResponse < JsonMessage
         required :handles, [Object]
       end


### PR DESCRIPTION
this commit added an update handle message for v2 api, which will be then required by ccng in parsing the message from service gateway in update handle to validate whether the handle format is correct or not.
