### PR TITLE
Allow the service instance guid to be passed during a service bind

### DIFF
--- a/lib/services/api/messages.rb
+++ b/lib/services/api/messages.rb
@@ -124,9 +124,10 @@ module VCAP
       end
 
       class GatewayBindRequest < JsonMessage
-        required :service_id,    String
-        required :label,         String
-        required :email,         String
+        required :service_id,     String
+        required :label,          String
+        required :email,          String
+        optional :service_instance_guid, String
         required :binding_options
       end
 


### PR DESCRIPTION
When binding a service, it would be really helpful if the CC could send to the service gateway the GUID of the service instance being bound. By making this field optional, vcap-common should still be backwords compatible with v1 CC/services.
