### PR TITLE
Support https service gateways

### DIFF
--- a/lib/services/api/clients/service_gateway_client.rb
+++ b/lib/services/api/clients/service_gateway_client.rb
@@ -163,7 +163,13 @@ module VCAP::Services::Api
         klass = METHODS_MAP[http_method]
         req = klass.new(path, initheader=@hdrs)
         req.body = msg.encode
-        resp = Net::HTTP.new(uri.host, uri.port).start {|http| http.request(req)}
+        resp = Net::HTTP.new(uri.host, uri.port).start {|http|
+          if uri.is_a?(URI::HTTPS)
+            http.use_ssl = true
+          end
+
+          http.request(req)
+        }
         code = resp.code.to_i
         body = resp.body
       end


### PR DESCRIPTION
The service_gateway_client doesn't support service gateways using ssl.  This PR adds support for ssl.
