### PR TITLE
Support for ssl service gateways

### DIFF
--- a/lib/services/api/clients/service_gateway_client.rb
+++ b/lib/services/api/clients/service_gateway_client.rb
@@ -159,7 +159,12 @@ module VCAP::Services::Api
         request = klass.new(path, headers)
         request.body = msg.encode
 
-        response = Net::HTTP.new(uri.host, uri.port).start do |http|
+        opts = {}
+        if uri.scheme == "https"
+          opts[:use_ssl] = true
+        end
+        
+        response = Net::HTTP.start(uri.host, uri.port, opts) do |http|
           http.request(request)
         end
 

--- a/spec/unit/service_gateway_client_spec.rb
+++ b/spec/unit/service_gateway_client_spec.rb
@@ -107,6 +107,24 @@ module VCAP::Services::Api
 
         request.should have_been_made
       end
+      
+      describe '#perform_request (https)' do
+        let(:url) { 'https://localhost' }
+
+        it 'makes https GET requests' do
+          request = stub_request(:get, 'https://localhost/path1').
+          with(headers: {
+            "X-VCAP-Request-ID" => request_id,
+            VCAP::Services::Api::GATEWAY_TOKEN_HEADER => token
+          }).
+          to_return(status: 200, body: 'data')
+
+          result = http_client.perform_request(:get, '/path1')
+          result.should == 'data'
+
+          request.should have_been_made
+        end
+      end
 
       context "when request_id is nil" do
         it "makes POST requests without the X-VCAP-Request-ID header" do


### PR DESCRIPTION
The service_gateway_client doesn't support service gateways using ssl. This PR adds support for ssl.
