### PR TITLE
Symbolize kyes in `config` before accessing it

### DIFF
--- a/lib/cf/registrar.rb
+++ b/lib/cf/registrar.rb
@@ -18,6 +18,8 @@ module Cf
     def initialize(config)
       @logger = Steno.logger("cf.registrar")
 
+      config = symbolize_keys(config)
+
       @message_bus_uri = config[:mbus]
       @host = config[:host]
       @port = config[:port]
@@ -119,6 +121,15 @@ module Cf
       @registration_timer = EM.add_periodic_timer(interval) do
         send_registration_message
       end
+    end
+
+    def symbolize_keys(hash)
+      return hash unless hash.is_a? Hash
+      Hash[
+        hash.each_pair.map do |k, v|
+            [k.to_sym, symbolize_keys(v)]
+        end
+      ]
     end
   end
 end

--- a/spec/unit/registrar_spec.rb
+++ b/spec/unit/registrar_spec.rb
@@ -77,6 +77,13 @@ module Cf
           its(:uuid) { should_not be_nil }
         end
       end
+
+      context "when there are values with String keys" do
+        let(:config) { { "host" => "h", :varz => { "username" => "user" } } }
+
+        its(:host) { should eq "h" }
+        its(:username) { should eq "user" }
+      end
     end
 
     describe "#register_with_router" do


### PR DESCRIPTION
I found that sub keys in `config[:varz]` are Strings when the hash passed from bin/cf-registrar, because it is read from a config file. UAA fails to send varz credentials because of this bug.

Here is the error log in /var/vcap/sys/log/uaa/cf-registrar.log:

```
{"timestamp":1377275176.0350683,"message":"Could not register nil varz credentials","log_level":"error","source":"cf.registrar","data":{},"thread_id":13992060,"fiber_id":16611160,"process_id":22933,"file":"/var/vcap/data/packages/uaa/28.1/vcap-common/lib/cf/registrar.rb","lineno":48,"method":"register_varz_credentials"}
```
