### PR TITLE
Include job_name in register message if provided

### DIFF
--- a/lib/vcap/component.rb
+++ b/lib/vcap/component.rb
@@ -157,6 +157,7 @@ module VCAP
         uuid = VCAP.secure_uuid
         type = opts[:type]
         index = opts[:index]
+        job_name = opts[:job_name]
         uuid = "#{index}-#{uuid}" if index
         host = opts[:host] || VCAP.local_ip
         port = opts[:port] || VCAP.grab_ephemeral_port
@@ -174,6 +175,7 @@ module VCAP
           :credentials => auth,
           :start => Time.now
         }
+        @discover[:job_name] = job_name if job_name
 
         # Varz is customizable
         varz.synchronize do


### PR DESCRIPTION
Message format stays the same if job_name is not
provided.

Signed-off-by: Marco Voelz <marco.voelz@sap.com>