### PR TITLE
Use 1.2.3.4 as destination for detecting local IP

### DIFF
--- a/lib/vcap/common.rb
+++ b/lib/vcap/common.rb
@@ -8,7 +8,7 @@ require 'uuidtools'
 module VCAP
 
   WINDOWS = RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-  A_ROOT_SERVER = '198.41.0.4'
+  A_ROOT_SERVER = '1.2.3.4'
 
   def self.local_ip(route = A_ROOT_SERVER)
     route ||= A_ROOT_SERVER


### PR DESCRIPTION
Use the same non-routable IP address used [here](https://github.com/pivotal-golang/localip/blob/master/localip.go#L7) when detecting the local IP.

There are currently 3 IPs being used for local IP detection:
- `1.2.3.4`: https://github.com/pivotal-golang/localip/blob/master/localip.go#L7
- `198.41.0.4` here, in vcap_common
- `8.8.8.8`: https://github.com/cloudfoundry/warden/pull/103/files#diff-d25b17d8aa906b299399e4cfd6479c8aL24
